### PR TITLE
FEAT: Use published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\""
   },
   "dependencies": {
+    "@lifeomic/chromicons": "^0.0.1",
     "@reach/alert": "^0.11.2",
     "@reach/dialog": "^0.11.2",
     "@tailwindui/react": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,6 +1051,11 @@
     postcss "7.0.32"
     purgecss "^2.3.0"
 
+"@lifeomic/chromicons@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-0.0.1.tgz#279e16f2dc039ede6c635013991910ffcf5ef1ec"
+  integrity sha512-sYelx+alVheOwYnZ+rVA1s+EyorIZoeAXa5lW9a8n0BzoEtgiFEhxWwconqAzX2LXSNB6xiRW7MS8EfQFtYQ8w==
+
 "@next/react-dev-overlay@9.5.3":
   version "9.5.3"
   resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-9.5.3.tgz#3275301f08045ecc709e3273031973a1f5e81427"


### PR DESCRIPTION
### Changes

- Use newly published `@lifeomic/chromicons` package