### PR TITLE
FEAT: Purge Tailwind CSS

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,10 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  purge: false,
+  purge: {
+    enabled: true,
+    content: ['./src/**/*.js'],
+  },
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
### Changes

- Use the built-in Tailwind CSS purging options to cut down on the output of CSS.  I experimented with both this option, as well as the less recommended `mode: 'all'` (in branch `purge-tailwind-css`).  Details can be found at https://tailwindcss.com/docs/controlling-file-size#enabling-manually

This takes our CSS file from about 196k to 4.3k