### PR TITLE
FEAT: Use latest chromicons + generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "dev": "next",
     "export": "next export",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
+    "generate:icon-metadata": "node ./scripts/generate-new-icon-metadata.js",
     "lint": "eslint --fix .",
     "start": "next start"
   },
   "dependencies": {
-    "@lifeomic/chromicons": "^0.0.3",
+    "@lifeomic/chromicons": "^0.0.4",
     "@reach/alert": "^0.11.2",
     "@reach/dialog": "^0.11.2",
     "@tailwindui/react": "^0.1.1",
@@ -31,6 +32,7 @@
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0",
     "file-loader": "^6.1.0",
+    "json5": "^2.1.3",
     "postcss-flexbugs-fixes": "4.2.1",
     "postcss-focus-visible": "^5.0.0",
     "postcss-preset-env": "^6.7.0",

--- a/scripts/generate-new-icon-metadata.js
+++ b/scripts/generate-new-icon-metadata.js
@@ -1,0 +1,54 @@
+/**
+ * This file allows us to determine which icons are newly added so we can add
+ * metadata about them.
+ */
+
+const { promises: fs } = require('fs');
+const JSON5 = require('json5');
+
+(async () => {
+  try {
+    const metadataOutput = {};
+
+    const allChromicons = await fs.readdir(
+      './node_modules/@lifeomic/chromicons/react/lined'
+    );
+
+    const actualChromicons = allChromicons
+      // We don't care about the index file
+      .filter((f) => f !== 'index.js')
+      // We only want the component name, not the file extension
+      .map((f) => f.substring(0, f.indexOf('.js')));
+
+    const metaFile = await fs.readFile('./src/util/metadata.js');
+    const metaFileAsString = metaFile.toString();
+
+    const existingMetaAsObject = metaFileAsString.substring(
+      // Cut out the cruft that'll botch us converting this to a valid JSON object
+      metaFileAsString.indexOf('{') + 1,
+      metaFileAsString.lastIndexOf('};')
+    );
+
+    const existingMetaParsed = JSON5.parse('{' + existingMetaAsObject + '}');
+
+    actualChromicons.forEach((i) => {
+      if (existingMetaParsed[i]) {
+        metadataOutput[i] = existingMetaParsed[i];
+      } else {
+        console.log(`✨ Icon "${i}" is new! Adding a new entry...`);
+
+        metadataOutput[i] = {
+          description: '',
+          categories: [],
+        };
+      }
+    });
+
+    await fs.writeFile(
+      './src/util/metadata.js',
+      `export default ${JSON5.stringify(metadataOutput, null, 2)};\n`
+    );
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/src/util/metadata.js
+++ b/src/util/metadata.js
@@ -11,6 +11,10 @@ export default {
     description: '',
     categories: [],
   },
+  Apple: {
+    description: '',
+    categories: [],
+  },
   Archive: {
     description: '',
     categories: [],
@@ -31,7 +35,7 @@ export default {
     description: '',
     categories: [],
   },
-  BarChart2: {
+  Award: {
     description: '',
     categories: [],
   },
@@ -39,11 +43,15 @@ export default {
     description: '',
     categories: [],
   },
-  BellOff: {
+  BarChart2: {
     description: '',
     categories: [],
   },
   Bell: {
+    description: '',
+    categories: [],
+  },
+  BellOff: {
     description: '',
     categories: [],
   },
@@ -55,11 +63,15 @@ export default {
     description: '',
     categories: [],
   },
+  Camera: {
+    description: '',
+    categories: [],
+  },
   CameraOff: {
     description: '',
     categories: [],
   },
-  Camera: {
+  Check: {
     description: '',
     categories: [],
   },
@@ -68,10 +80,6 @@ export default {
     categories: [],
   },
   CheckSquare: {
-    description: '',
-    categories: [],
-  },
-  Check: {
     description: '',
     categories: [],
   },
@@ -103,15 +111,15 @@ export default {
     description: '',
     categories: [],
   },
+  Cloud: {
+    description: '',
+    categories: [],
+  },
   CloudLightning: {
     description: '',
     categories: [],
   },
   CloudOff: {
-    description: '',
-    categories: [],
-  },
-  Cloud: {
     description: '',
     categories: [],
   },
@@ -135,6 +143,10 @@ export default {
     description: '',
     categories: [],
   },
+  Dna: {
+    description: '',
+    categories: [],
+  },
   DollarSign: {
     description: '',
     categories: [],
@@ -143,11 +155,11 @@ export default {
     description: '',
     categories: [],
   },
-  Edit2: {
+  Edit: {
     description: '',
     categories: [],
   },
-  Edit: {
+  Edit2: {
     description: '',
     categories: [],
   },
@@ -155,19 +167,19 @@ export default {
     description: '',
     categories: [],
   },
-  EyeOff: {
-    description: '',
-    categories: [],
-  },
   Eye: {
     description: '',
     categories: [],
   },
-  FileText: {
+  EyeOff: {
     description: '',
     categories: [],
   },
   File: {
+    description: '',
+    categories: [],
+  },
+  FileText: {
     description: '',
     categories: [],
   },
@@ -176,6 +188,10 @@ export default {
     categories: [],
   },
   Folder: {
+    description: '',
+    categories: [],
+  },
+  Hangup: {
     description: '',
     categories: [],
   },
@@ -247,11 +263,19 @@ export default {
     description: '',
     categories: [],
   },
+  MessageSquare: {
+    description: '',
+    categories: [],
+  },
   Mic: {
     description: '',
     categories: [],
   },
   MinusCircle: {
+    description: '',
+    categories: [],
+  },
+  Moon: {
     description: '',
     categories: [],
   },
@@ -271,7 +295,15 @@ export default {
     description: '',
     categories: [],
   },
+  Phone: {
+    description: '',
+    categories: [],
+  },
   PieChart: {
+    description: '',
+    categories: [],
+  },
+  Plus: {
     description: '',
     categories: [],
   },
@@ -283,15 +315,15 @@ export default {
     description: '',
     categories: [],
   },
-  Plus: {
-    description: '',
-    categories: [],
-  },
   RefreshCw: {
     description: '',
     categories: [],
   },
   RotateCcw: {
+    description: '',
+    categories: [],
+  },
+  Running: {
     description: '',
     categories: [],
   },
@@ -316,6 +348,10 @@ export default {
     categories: [],
   },
   SkipForward: {
+    description: '',
+    categories: [],
+  },
+  Smartphone: {
     description: '',
     categories: [],
   },
@@ -351,6 +387,10 @@ export default {
     description: '',
     categories: [],
   },
+  User: {
+    description: '',
+    categories: [],
+  },
   UserCheck: {
     description: '',
     categories: [],
@@ -363,11 +403,11 @@ export default {
     description: '',
     categories: [],
   },
-  User: {
+  Users: {
     description: '',
     categories: [],
   },
-  Users: {
+  Video: {
     description: '',
     categories: [],
   },
@@ -375,11 +415,11 @@ export default {
     description: '',
     categories: [],
   },
-  XCircle: {
+  X: {
     description: '',
     categories: [],
   },
-  X: {
+  XCircle: {
     description: '',
     categories: [],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,10 +1051,10 @@
     postcss "7.0.32"
     purgecss "^2.3.0"
 
-"@lifeomic/chromicons@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-0.0.3.tgz#7f0bb79dd83bfad0527f2463b5675b3d35de0c78"
-  integrity sha512-k5Z092wg/Q2DLdiLuOd2xmLVNCBAlTlmrZNGRtI+vggOb+hC7dNxRQyX2r5dC/Wgs+SWoSS+IjDDsPf6M6GAtg==
+"@lifeomic/chromicons@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-0.0.4.tgz#08f62fb3882f310169c3cd55ed2c260f49fb13c5"
+  integrity sha512-QU+HFRUjyELGziMIXal8bzta7MoGitMKcGD/Boo+a6o0v7pOZRCg1fkzmtK9t7CPwZhhEtKr39sxDD+mj3YmnQ==
 
 "@next/react-dev-overlay@9.5.3":
   version "9.5.3"
@@ -3641,7 +3641,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.0, json5@^2.1.2:
+json5@^2.1.0, json5@^2.1.2, json5@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==


### PR DESCRIPTION
### Changes

- Use latest chromicons
- Wrote script to auto-generate the `metadata.js` file for us.  It will find new icons and add them to the list.  Should make it easier when adding new icons to fill out this information as well.  This was the best I could come up with.  I'm using JSON5 instead of having to convert the object into something the native `JSON.parse` would understand.  