### PR TITLE
Add filtering and searching for icons, relax CSS purging in dev mode, external link fixes

### DIFF
--- a/src/components/categoryFilters.js
+++ b/src/components/categoryFilters.js
@@ -1,0 +1,71 @@
+import { Radio } from './radio';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+export const CategoryFilters = ({ className, onChange }) => {
+  const router = useRouter();
+
+  // On mount, get our `tab` query param
+  // NOTE: For whatever reason `router.query` is not updated on initial render.
+  //       Will file an issue / dig in some more!
+  const [selectedOption, setSelectedOption] = useState(() => {
+    const params = new URLSearchParams(router.asPath.replace('/', ''));
+    const tab = params.get('tab');
+
+    return tab || 'all';
+  });
+
+  const handleOnChange = (e) => {
+    router.push({
+      query: e.target.value !== 'all' ? { tab: e.target.value } : {},
+    });
+    setSelectedOption(e.target.value);
+    onChange?.(e.target.value);
+  };
+
+  return (
+    <form className={className} onSubmit={(e) => e.preventDefault()}>
+      <fieldset role="radiogroup">
+        <legend className="sr-only">Filter icons by category</legend>
+        <div className="flex justify-between items-center space-x-12">
+          <Radio
+            checked={selectedOption === 'all'}
+            className="py-8"
+            id="all"
+            name="category"
+            onChange={handleOnChange}
+            text="All"
+            value="all"
+          />
+          <Radio
+            checked={selectedOption === 'ui'}
+            className="py-8"
+            id="ui"
+            name="category"
+            onChange={handleOnChange}
+            text="App / UI"
+            value="ui"
+          />
+          <Radio
+            checked={selectedOption === 'science'}
+            className="py-8"
+            id="science"
+            name="category"
+            onChange={handleOnChange}
+            text="Science"
+            value="science"
+          />
+          <Radio
+            checked={selectedOption === 'health'}
+            className="py-8"
+            id="health"
+            name="category"
+            onChange={handleOnChange}
+            text="Health"
+            value="health"
+          />
+        </div>
+      </fieldset>
+    </form>
+  );
+};

--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -24,7 +24,7 @@ export const Radio = ({
       />
       <label
         htmlFor={id}
-        className={`text-gray-800 uppercase font-semibold tracking-widest cursor-pointer transition-opacity duration-300 ease-in-out hover:opacity-75 ${
+        className={`text-gray-800 uppercase font-semibold tracking-widest cursor-pointer transition-opacity duration-300 ease-in-out text-sm md:text-base hover:opacity-75 ${
           checked && 'text-green-400'
         }`}
       >

--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -1,0 +1,52 @@
+import { Transition } from '@tailwindui/react';
+import clsx from 'clsx';
+
+export const Radio = ({
+  className,
+  checked,
+  id,
+  name,
+  onChange,
+  text,
+  value,
+}) => {
+  return (
+    <div className={clsx('relative', className)}>
+      <input
+        checked={checked}
+        className="sr-only"
+        id={id}
+        name={name}
+        onChange={onChange}
+        role="radio"
+        type="radio"
+        value={value}
+      />
+      <label
+        htmlFor={id}
+        className={`text-gray-800 uppercase font-semibold tracking-widest cursor-pointer transition-opacity duration-300 hover:opacity-75 ${
+          checked && 'text-green-400'
+        }`}
+      >
+        {text}
+      </label>
+      <Transition
+        show={checked}
+        enter="transition-opacity duration-300 ease-in"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-250 ease-in-out"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <span
+          className="absolute left-0 right-0 top-0 text-center text-xl text-green-400"
+          role="presentation"
+          aria-hidden
+        >
+          •
+        </span>
+      </Transition>
+    </div>
+  );
+};

--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -24,7 +24,7 @@ export const Radio = ({
       />
       <label
         htmlFor={id}
-        className={`text-gray-800 uppercase font-semibold tracking-widest cursor-pointer transition-opacity duration-300 hover:opacity-75 ${
+        className={`text-gray-800 uppercase font-semibold tracking-widest cursor-pointer transition-opacity duration-300 ease-in-out hover:opacity-75 ${
           checked && 'text-green-400'
         }`}
       >

--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -1,7 +1,7 @@
 import { Search } from '@lifeomic/chromicons/react/lined';
 import clsx from 'clsx';
 
-export const SearchField = ({ className, onChange, value }) => {
+export const SearchField = ({ className, inputClassName, onChange, value }) => {
   return (
     <form
       className={clsx('relative flex items-center', className)}
@@ -14,7 +14,10 @@ export const SearchField = ({ className, onChange, value }) => {
         id="search-icons"
         type="search"
         placeholder="Search icons"
-        className="appearance-none border border-grey bg-gray-200 rounded-lg pl-10 pr-4 py-2 text-black focus:outline-none focus:border-purple-400"
+        className={clsx(
+          'appearance-none border border-grey bg-gray-200 rounded-lg pl-10 pr-4 py-2 text-black focus:outline-none focus:border-purple-400',
+          inputClassName
+        )}
         onChange={onChange}
         value={value}
       />

--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -1,7 +1,10 @@
-export const SearchField = ({ onChange }) => {
+import { Search } from '@lifeomic/chromicons/react/lined';
+import clsx from 'clsx';
+
+export const SearchField = ({ className, onChange }) => {
   return (
     <form
-      className="relative flex items-center"
+      className={clsx('relative flex items-center', className)}
       onSubmit={(e) => e.preventDefault()}
     >
       <label className="sr-only" htmlFor="search-icons" aria-hidden>
@@ -11,17 +14,11 @@ export const SearchField = ({ onChange }) => {
         id="search-icons"
         type="search"
         placeholder="Search icons"
-        className="appearance-none border border-grey bg-gray-200 rounded-lg pl-8 pr-4 py-2 text-black focus:outline-none focus:border-purple-400"
+        className="appearance-none border border-grey bg-gray-200 rounded-lg pl-10 pr-4 py-2 text-black focus:outline-none focus:border-purple-400"
         onChange={onChange}
       />
-      <div className="absolute pin-y pin-l pl-3 flex items-center justify-center">
-        <svg
-          className="fill-current text-grey h-4 w-4"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-        >
-          <path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z"></path>
-        </svg>
+      <div className="absolute pl-3 flex items-center justify-center">
+        <Search className="fill-current text-grey h-4 w-4" />
       </div>
     </form>
   );

--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -1,7 +1,7 @@
 import { Search } from '@lifeomic/chromicons/react/lined';
 import clsx from 'clsx';
 
-export const SearchField = ({ className, onChange }) => {
+export const SearchField = ({ className, onChange, value }) => {
   return (
     <form
       className={clsx('relative flex items-center', className)}
@@ -16,6 +16,7 @@ export const SearchField = ({ className, onChange }) => {
         placeholder="Search icons"
         className="appearance-none border border-grey bg-gray-200 rounded-lg pl-10 pr-4 py-2 text-black focus:outline-none focus:border-purple-400"
         onChange={onChange}
+        value={value}
       />
       <div className="absolute pl-3 flex items-center justify-center">
         <Search className="fill-current text-grey h-4 w-4" />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,15 +1,16 @@
 import { CategoryFilters } from '../components/categoryFilters';
 import { Chromicons } from '../components/icons/chromicons';
-import { Flag } from '@lifeomic/chromicons/react/lined';
 import { IconModal } from '../components/iconModal';
 import { LifeOmic } from '../components/icons/lifeomic';
 import { SearchField } from '../components/searchField';
 import { Tile } from '../components/tile';
+import { Transition } from '@tailwindui/react';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import {
   CheckCircle,
   Chroma,
+  Flag,
   Lifeology,
 } from '@lifeomic/chromicons/react/lined';
 import * as allLinedChromicons from '@lifeomic/chromicons/react/lined';
@@ -39,6 +40,7 @@ export default function IndexPage({ pkgVersion }) {
   const router = useRouter();
 
   const [iconInView, setIconInView] = useState(null);
+  const [searchText, setSearchText] = useState(null);
 
   // On mount, get our `tab` query param and filter our icons based on it
   // NOTE: For whatever reason `router.query` is not updated on initial render.
@@ -136,6 +138,7 @@ export default function IndexPage({ pkgVersion }) {
               className="flex items-center duration-300 ease-in-out transition-opacity hover:opacity-75 focus:outline-none focus-visible:shadow-outline focus-visible:underline"
               href="https://github.com/lifeomic/chromicons"
               target="_blank"
+              rel="noopener noreferrer"
             >
               <svg
                 className="mr-2"
@@ -189,6 +192,8 @@ export default function IndexPage({ pkgVersion }) {
           <CategoryFilters
             className="mt-4"
             onChange={(filter) => {
+              setSearchText('');
+
               if (filter === 'all') {
                 setVisibleIcons(getChromicons());
                 return;
@@ -224,9 +229,12 @@ export default function IndexPage({ pkgVersion }) {
           />
           <SearchField
             className="mb-4 md:mb-0"
+            value={searchText}
             onChange={(e) => {
               const { tab } = router.query;
               const search = e.target.value;
+
+              setSearchText(e.target.value);
 
               const filteredIcons = tab
                 ? getChromicons()?.filter((icon) =>
@@ -251,21 +259,48 @@ export default function IndexPage({ pkgVersion }) {
             }}
           />
         </div>
-        <div className="grid grid-cols-2 gap-2 px-4 my-4 max-w-6xl mx-auto sm:px-6 lg:px-16 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-          {visibleIcons?.map((icon) => {
-            const Icon = icon.reactComponent;
-            return (
-              <Tile
-                name={icon.name}
-                key={icon.name}
-                isOpen={iconInView?.name === icon?.name}
-                onClick={() => setIconInView(icon)}
+        {visibleIcons?.length > 0 ? (
+          <div className="grid grid-cols-2 gap-2 px-4 my-4 max-w-6xl mx-auto sm:px-6 lg:px-16 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+            {visibleIcons?.map((icon) => {
+              const Icon = icon.reactComponent;
+              return (
+                <Tile
+                  name={icon.name}
+                  key={icon.name}
+                  isOpen={iconInView?.name === icon?.name}
+                  onClick={() => setIconInView(icon)}
+                >
+                  <Icon className="h-6 w-6" />
+                </Tile>
+              );
+            })}
+          </div>
+        ) : (
+          <Transition
+            appear={true}
+            show={true}
+            enter="transition-opacity duration-300 ease-in"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition-opacity duration-250 ease-in-out"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="py-10 text-center font-bold space-y-2">
+              <p>It looks like we don't have an icon for that yet!</p>
+              <a
+                href={`https://github.com/lifeomic/chromicons/issues/new?title=${encodeURIComponent(
+                  `"${searchText}" icon request`
+                )}`}
+                className="text-sm text-blue-600 duration-300 ease-in-out transition-opacity hover:opacity-75 focus:outline-none focus-visible:shadow-outline focus-visible:underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
-                <Icon className="h-6 w-6" />
-              </Tile>
-            );
-          })}
-        </div>
+                Please file a GitHub issue.
+              </a>
+            </div>
+          </Transition>
+        )}
       </main>
 
       <footer className="flex flex-col justify-center bg-gray-200 border-gray-300 border-t py-12 space-y-6 md:py-14 px-4 sm:px-6 lg:px-16 leading-5">
@@ -301,6 +336,7 @@ export default function IndexPage({ pkgVersion }) {
                 className="font-bold duration-300 ease-in-out transition-opacity hover:opacity-75 focus:outline-none focus-visible:shadow-outline focus-visible:underline"
                 href="https://twitter.com/_ynotdraw"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 @_ynotdraw
               </a>
@@ -314,6 +350,7 @@ export default function IndexPage({ pkgVersion }) {
                 className="font-bold duration-300 ease-in-out transition-opacity hover:opacity-75 focus:outline-none focus-visible:shadow-outline focus-visible:underline"
                 href="https://www.lifeomic.com"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 LifeOmic
               </a>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -228,7 +228,8 @@ export default function IndexPage({ pkgVersion }) {
             }}
           />
           <SearchField
-            className="mb-4 md:mb-0"
+            className="mb-4 w-full sm:px-6 md:px-0 md:mb-0 md:w-auto"
+            inputClassName="w-full md:w-auto"
             value={searchText}
             onChange={(e) => {
               const { tab } = router.query;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -40,7 +40,7 @@ export default function IndexPage({ pkgVersion }) {
   const router = useRouter();
 
   const [iconInView, setIconInView] = useState(null);
-  const [searchText, setSearchText] = useState(null);
+  const [searchText, setSearchText] = useState('');
 
   // On mount, get our `tab` query param and filter our icons based on it
   // NOTE: For whatever reason `router.query` is not updated on initial render.

--- a/src/util/metadata.js
+++ b/src/util/metadata.js
@@ -1,438 +1,438 @@
 export default {
   Activity: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health'],
   },
   AlertCircle: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   AlertTriangle: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Apple: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health'],
   },
   Archive: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ArrowDown: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ArrowLeft: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ArrowRight: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ArrowUp: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Award: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   BarChart: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   BarChart2: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Bell: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   BellOff: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   BookOpen: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   Box: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Camera: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   CameraOff: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Check: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   CheckCircle: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   CheckSquare: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ChevronDown: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ChevronLeft: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ChevronRight: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ChevronUp: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Chroma: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Clipboard: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Clock: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   Cloud: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   CloudLightning: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   CloudOff: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   Code: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   Copy: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   CornerLeftUp: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Cpu: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   Database: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Dna: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   DollarSign: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Download: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Edit: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Edit2: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ExternalLink: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Eye: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   EyeOff: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   File: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   FileText: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   Flag: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Folder: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Hangup: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Hash: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Heatmap: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   HelpCircle: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Home: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Image: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Info: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Key: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Layout: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Lifeology: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   Link: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   List: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Loader: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Lock: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Login: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Mail: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Maximize: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Menu: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   MessageSquare: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Mic: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   MinusCircle: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Moon: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   MoreHorizontal: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Needle: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   Oncoprint: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Package: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Phone: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   PieChart: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Plus: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   PlusCircle: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   PlusSquare: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   RefreshCw: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   RotateCcw: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Running: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health'],
   },
   Scatter: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Search: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Send: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Settings: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   SkipBack: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   SkipForward: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Smartphone: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Sun: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   SurvivalCurve: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   ToggleLeft: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ToggleRight: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Trash: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   TrendingUp: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Type: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   UploadCloud: {
     description: '',
-    categories: [],
+    categories: ['ui', 'health', 'science'],
   },
   User: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   UserCheck: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   UserMinus: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   UserPlus: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Users: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Video: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Watch: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   X: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   XCircle: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   Zap: {
     description: '',
-    categories: [],
+    categories: ['ui', 'science'],
   },
   ZoomIn: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
   ZoomOut: {
     description: '',
-    categories: [],
+    categories: ['ui'],
   },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,10 +6,13 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  purge: {
-    enabled: true,
-    content: ['./src/**/*.js'],
-  },
+  purge:
+    process.env.NODE_ENV === 'production'
+      ? {
+          enabled: true,
+          content: ['./src/**/*.js'],
+        }
+      : false,
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
### Changes

- Adjust Tailwind CSS purging in dev vs prod
  - I noticed I was having issues when developing locally, where I would add a new class I haven't used before and I'd have to stop and restart my server for it to show up.  I narrowed it down to the purging.  Basically in dev mode, we won't purge at all, but in prod mode we will.  I'll double-check this once it gets deployed to ensure I didn't bust anything, but should be fine.
- Add ability to filter icons by category
- Wire up filter category to the `tab` query param so that users can be taken straight to the selected tab
- Add ability to search icons by name or description
- Add link to create a GitHub issue in the Chromicons repo when an icon they're searching for doesn't exist
- Add `rel="noopener noreferrer"` to external links

<img width="1203" alt="Screen Shot 2020-10-01 at 3 35 53 PM" src="https://user-images.githubusercontent.com/8069555/94865196-2c574400-040b-11eb-9e6a-bb2718b34f59.png">

<img width="1518" alt="Screen Shot 2020-10-01 at 5 19 28 PM" src="https://user-images.githubusercontent.com/8069555/94865207-2feacb00-040b-11eb-8586-e957cc5a3bf4.png">

<img width="612" alt="Screen Shot 2020-10-01 at 5 22 34 PM" src="https://user-images.githubusercontent.com/8069555/94865212-32e5bb80-040b-11eb-8990-a1f6b0f54627.png">
