### PR TITLE
FIX: Remove query params for now 😭

### DIFF
--- a/src/components/categoryFilters.js
+++ b/src/components/categoryFilters.js
@@ -1,25 +1,7 @@
 import { Radio } from './radio';
-import { useRouter } from 'next/router';
-import { useState } from 'react';
 
-export const CategoryFilters = ({ className, onChange }) => {
-  const router = useRouter();
-
-  // On mount, get our `tab` query param
-  // NOTE: For whatever reason `router.query` is not updated on initial render.
-  //       Will file an issue / dig in some more!
-  const [selectedOption, setSelectedOption] = useState(() => {
-    const params = new URLSearchParams(router.asPath.replace('/', ''));
-    const tab = params.get('tab');
-
-    return tab || 'all';
-  });
-
+export const CategoryFilters = ({ className, onChange, selectedTab }) => {
   const handleOnChange = (e) => {
-    router.push({
-      query: e.target.value !== 'all' ? { tab: e.target.value } : {},
-    });
-    setSelectedOption(e.target.value);
     onChange?.(e.target.value);
   };
 
@@ -29,7 +11,7 @@ export const CategoryFilters = ({ className, onChange }) => {
         <legend className="sr-only">Filter icons by category</legend>
         <div className="flex justify-between items-center space-x-12">
           <Radio
-            checked={selectedOption === 'all'}
+            checked={selectedTab === 'all'}
             className="py-8"
             id="all"
             name="category"
@@ -38,7 +20,7 @@ export const CategoryFilters = ({ className, onChange }) => {
             value="all"
           />
           <Radio
-            checked={selectedOption === 'ui'}
+            checked={selectedTab === 'ui'}
             className="py-8"
             id="ui"
             name="category"
@@ -47,7 +29,7 @@ export const CategoryFilters = ({ className, onChange }) => {
             value="ui"
           />
           <Radio
-            checked={selectedOption === 'science'}
+            checked={selectedTab === 'science'}
             className="py-8"
             id="science"
             name="category"
@@ -56,7 +38,7 @@ export const CategoryFilters = ({ className, onChange }) => {
             value="science"
           />
           <Radio
-            checked={selectedOption === 'health'}
+            checked={selectedTab === 'health'}
             className="py-8"
             id="health"
             name="category"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,6 @@ import { LifeOmic } from '../components/icons/lifeomic';
 import { SearchField } from '../components/searchField';
 import { Tile } from '../components/tile';
 import { Transition } from '@tailwindui/react';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import {
   CheckCircle,
@@ -37,22 +36,11 @@ export function getStaticProps() {
 }
 
 export default function IndexPage({ pkgVersion }) {
-  const router = useRouter();
-
   const [iconInView, setIconInView] = useState(null);
+  const [selectedTab, setSelectedTab] = useState('all');
   const [searchText, setSearchText] = useState('');
 
-  // On mount, get our `tab` query param and filter our icons based on it
-  // NOTE: For whatever reason `router.query` is not updated on initial render.
-  //       Will file an issue / dig in some more!
-  const [visibleIcons, setVisibleIcons] = useState(() => {
-    const params = new URLSearchParams(router.asPath.replace('/', ''));
-    const tab = params.get('tab');
-
-    return tab
-      ? getChromicons()?.filter?.((icon) => icon?.categories?.includes(tab))
-      : getChromicons();
-  });
+  const [visibleIcons, setVisibleIcons] = useState(() => getChromicons('all'));
 
   return (
     <>
@@ -191,7 +179,9 @@ export default function IndexPage({ pkgVersion }) {
         <div className="flex justify-between items-center shadow-md px-4 flex-col md:flex-row sm:px-6 lg:px-16">
           <CategoryFilters
             className="mt-4"
+            selectedTab={selectedTab}
             onChange={(filter) => {
+              setSelectedTab(filter);
               setSearchText('');
 
               if (filter === 'all') {
@@ -232,16 +222,16 @@ export default function IndexPage({ pkgVersion }) {
             inputClassName="w-full md:w-auto"
             value={searchText}
             onChange={(e) => {
-              const { tab } = router.query;
               const search = e.target.value;
 
               setSearchText(e.target.value);
 
-              const filteredIcons = tab
-                ? getChromicons()?.filter((icon) =>
-                    icon?.categories?.includes(tab)
-                  )
-                : getChromicons();
+              const filteredIcons =
+                selectedTab !== 'all'
+                  ? getChromicons()?.filter((icon) =>
+                      icon?.categories?.includes(selectedTab)
+                    )
+                  : getChromicons();
 
               if (!search) {
                 setVisibleIcons(filteredIcons);


### PR DESCRIPTION
### Changes

- With GitHub Pages, we use the an asset/env prefix which gives us `https://lifeomic.github.io/chromicons.com/`.  When in dev mode, we have no issues adding query params to the URL; however, when deployed out on GitHub Pages we get: `https://lifeomic.github.io/?tab=health`.  I'm going to revert query param'ing these for now and figure out a better solution in the mean time.  Bummer 😭 