### PR TITLE
Use latest chromicons package (with new icons too)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,6 @@
 const debug = process.env.NODE_ENV !== 'production';
 
-const withTranspileModules = require('next-transpile-modules')([
-  '@lifeomic/chromicons',
-]);
-
-module.exports = withTranspileModules({
+module.exports = {
   assetPrefix: !debug ? '/chromicons.com/' : '',
 
   experimental: {
@@ -30,4 +26,4 @@ module.exports = withTranspileModules({
 
     return config;
   },
-});
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@lifeomic/chromicons": "^0.0.4",
+    "@lifeomic/chromicons": "^0.1.3",
     "@reach/alert": "^0.11.2",
     "@reach/dialog": "^0.11.2",
     "@tailwindui/react": "^0.1.1",
@@ -20,7 +20,6 @@
     "clsx": "^1.1.1",
     "focus-visible": "^5.1.0",
     "next": "^9.5.5",
-    "next-transpile-modules": "^4.1.0",
     "postcss-import": "^12.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/scripts/generate-new-icon-metadata.js
+++ b/scripts/generate-new-icon-metadata.js
@@ -11,14 +11,14 @@ const JSON5 = require('json5');
     const metadataOutput = {};
 
     const allChromicons = await fs.readdir(
-      './node_modules/@lifeomic/chromicons/react/lined'
+      './node_modules/@lifeomic/chromicons/src/lined'
     );
 
     const actualChromicons = allChromicons
       // We don't care about the index file
-      .filter((f) => f !== 'index.js')
+      .filter((f) => f !== 'index.tsx')
       // We only want the component name, not the file extension
-      .map((f) => f.substring(0, f.indexOf('.js')));
+      .map((f) => f.substring(0, f.indexOf('.tsx')));
 
     const metaFile = await fs.readFile('./src/util/metadata.js');
     const metaFileAsString = metaFile.toString();
@@ -39,7 +39,7 @@ const JSON5 = require('json5');
 
         metadataOutput[i] = {
           description: '',
-          categories: [],
+          categories: ['ui'],
         };
       }
     });

--- a/src/components/iconModal.js
+++ b/src/components/iconModal.js
@@ -1,8 +1,7 @@
-import { CheckCircle } from '@lifeomic/chromicons/react/lined';
+import { CheckCircle, X } from '@lifeomic/chromicons';
 import { DialogOverlay, DialogContent } from '@reach/dialog';
 import { Transition } from '@tailwindui/react';
 import { useEffect, useRef, useState } from 'react';
-import { X } from '@lifeomic/chromicons/react/lined';
 import Alert from '@reach/alert';
 import clsx from 'clsx';
 

--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -1,4 +1,4 @@
-import { Search } from '@lifeomic/chromicons/react/lined';
+import { Search } from '@lifeomic/chromicons';
 import clsx from 'clsx';
 
 export const SearchField = ({ className, inputClassName, onChange, value }) => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,13 +6,8 @@ import { SearchField } from '../components/searchField';
 import { Tile } from '../components/tile';
 import { Transition } from '@tailwindui/react';
 import { useState } from 'react';
-import {
-  CheckCircle,
-  Download,
-  Flag,
-  Lifeology,
-} from '@lifeomic/chromicons/react/lined';
-import * as allLinedChromicons from '@lifeomic/chromicons/react/lined';
+import { CheckCircle, Download, Flag, Lifeology } from '@lifeomic/chromicons';
+import * as allLinedChromicons from '@lifeomic/chromicons';
 import clsx from 'clsx';
 import Head from 'next/head';
 import metadata from '../util/metadata';

--- a/src/util/metadata.js
+++ b/src/util/metadata.js
@@ -55,6 +55,10 @@ export default {
     description: '',
     categories: ['ui'],
   },
+  Bold: {
+    description: '',
+    categories: ['ui'],
+  },
   BookOpen: {
     description: '',
     categories: ['ui', 'science'],
@@ -191,6 +195,10 @@ export default {
     description: '',
     categories: ['ui'],
   },
+  FontSize: {
+    description: '',
+    categories: ['ui'],
+  },
   Hangup: {
     description: '',
     categories: ['ui'],
@@ -198,6 +206,10 @@ export default {
   Hash: {
     description: '',
     categories: ['ui'],
+  },
+  Heart: {
+    description: '',
+    categories: ['ui', 'health', 'science'],
   },
   Heatmap: {
     description: '',
@@ -219,6 +231,10 @@ export default {
     description: '',
     categories: ['ui'],
   },
+  Italic: {
+    description: '',
+    categories: [],
+  },
   Key: {
     description: '',
     categories: ['ui'],
@@ -227,9 +243,21 @@ export default {
     description: '',
     categories: ['ui'],
   },
+  Leaf: {
+    description: '',
+    categories: [],
+  },
   Lifeology: {
     description: '',
     categories: ['ui', 'health', 'science'],
+  },
+  Lightbulb: {
+    description: '',
+    categories: ['ui', 'science'],
+  },
+  LineHeight: {
+    description: '',
+    categories: ['ui'],
   },
   Link: {
     description: '',
@@ -287,6 +315,10 @@ export default {
     description: '',
     categories: ['ui', 'health', 'science'],
   },
+  NumberList: {
+    description: '',
+    categories: ['ui'],
+  },
   Oncoprint: {
     description: '',
     categories: ['ui'],
@@ -302,6 +334,10 @@ export default {
   PieChart: {
     description: '',
     categories: ['ui'],
+  },
+  Plane: {
+    description: '',
+    categories: ['ui', 'science'],
   },
   Plus: {
     description: '',
@@ -354,6 +390,14 @@ export default {
   Smartphone: {
     description: '',
     categories: ['ui'],
+  },
+  Smile: {
+    description: '',
+    categories: ['ui'],
+  },
+  Star: {
+    description: '',
+    categories: ['ui', 'health', 'science'],
   },
   Sun: {
     description: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,10 +1071,10 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.0.tgz#6c9eafc78c1529248f8f4d92b0799a712b6052c6"
   integrity sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==
 
-"@lifeomic/chromicons@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-0.0.4.tgz#08f62fb3882f310169c3cd55ed2c260f49fb13c5"
-  integrity sha512-QU+HFRUjyELGziMIXal8bzta7MoGitMKcGD/Boo+a6o0v7pOZRCg1fkzmtK9t7CPwZhhEtKr39sxDD+mj3YmnQ==
+"@lifeomic/chromicons@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-0.1.3.tgz#2bc04d321a63d51eb0fef65379f356dac98f0095"
+  integrity sha512-gPhdQMfv70pBX/w7//vcolexHthqizISelXRpJ9d/fdxEupE+9+WVVinx23QnFJjnpR2AjWARGUzggiBL68FBQ==
 
 "@next/env@9.5.5":
   version "9.5.5"
@@ -1726,7 +1726,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3939,14 +3939,6 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
-
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -4126,14 +4118,6 @@ next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
-
-next-transpile-modules@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-4.1.0.tgz#b2d4bd29f3d4179014f7615720f360fdeec67ff7"
-  integrity sha512-brb9S2Dq7l01fV0fdZw1pO2cWMu7fFTclIV2nccmX2Jzwtz1c9iScPMqGyWP6/wglOPOColoJlHzOrSG6cnEIQ==
-  dependencies:
-    micromatch "^4.0.2"
-    slash "^3.0.0"
 
 next@^9.5.5:
   version "9.5.5"
@@ -4518,7 +4502,7 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -5573,11 +5557,6 @@ simple-swizzle@^0.2.2:
   integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
   dependencies:
     is-arrayish "^0.3.1"
-
-slash@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
-  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
### Changes

- Use latest chromicons package
  - We no longer need to transpile modules, as the chromicons package is ready to use out of the box
- Use Jay's latest icons
  - Related: https://github.com/lifeomic/chromicons/pull/26