### PR TITLE
Center content for all screen sizes

### DIFF
--- a/src/components/categoryFilters.js
+++ b/src/components/categoryFilters.js
@@ -12,7 +12,7 @@ export const CategoryFilters = ({ className, onChange, selectedTab }) => {
         <div className="flex justify-between items-center space-x-12">
           <Radio
             checked={selectedTab === 'all'}
-            className="py-8"
+            className="pt-10 pb-8"
             id="all"
             name="category"
             onChange={handleOnChange}
@@ -21,7 +21,7 @@ export const CategoryFilters = ({ className, onChange, selectedTab }) => {
           />
           <Radio
             checked={selectedTab === 'ui'}
-            className="py-8"
+            className="pt-10 pb-8"
             id="ui"
             name="category"
             onChange={handleOnChange}
@@ -30,7 +30,7 @@ export const CategoryFilters = ({ className, onChange, selectedTab }) => {
           />
           <Radio
             checked={selectedTab === 'science'}
-            className="py-8"
+            className="pt-10 pb-8"
             id="science"
             name="category"
             onChange={handleOnChange}
@@ -39,7 +39,7 @@ export const CategoryFilters = ({ className, onChange, selectedTab }) => {
           />
           <Radio
             checked={selectedTab === 'health'}
-            className="py-8"
+            className="pt-10 pb-8"
             id="health"
             name="category"
             onChange={handleOnChange}

--- a/src/components/icons/chromicons.js
+++ b/src/components/icons/chromicons.js
@@ -1,5 +1,5 @@
 export const Chromicons = ({ ...rootProps }) => (
-  <svg width={172} height={26} viewBox="0 0 172 26" fill="none" {...rootProps}>
+  <svg width={172} height={24} viewBox="0 0 172 24" fill="none" {...rootProps}>
     <path
       d="M15.84 10.341a7.088 7.088 0 10-.187 9.826M21.663 8.059v14.188M33.96 8.059v14.188M21.663 15.153H33.96"
       stroke="#fff"

--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -4,25 +4,27 @@ import clsx from 'clsx';
 export const SearchField = ({ className, inputClassName, onChange, value }) => {
   return (
     <form
-      className={clsx('relative flex items-center', className)}
+      className={clsx('relative flex items-center justify-center', className)}
       onSubmit={(e) => e.preventDefault()}
     >
       <label className="sr-only" htmlFor="search-icons" aria-hidden>
         Search icons
       </label>
-      <input
-        id="search-icons"
-        type="search"
-        placeholder="Search icons"
-        className={clsx(
-          'appearance-none border border-grey bg-gray-200 rounded-lg pl-10 pr-4 py-2 text-black focus:outline-none focus:border-purple-400',
-          inputClassName
-        )}
-        onChange={onChange}
-        value={value}
-      />
-      <div className="absolute pl-3 flex items-center justify-center">
-        <Search className="fill-current text-grey h-4 w-4" />
+      <div className="relative flex w-full md:w-auto">
+        <input
+          id="search-icons"
+          type="search"
+          placeholder="Search icons"
+          className={clsx(
+            'appearance-none border border-grey bg-gray-200 rounded-lg pl-10 pr-4 py-2 text-black bg-opacity-90 focus:outline-none focus:border-purple-400',
+            inputClassName
+          )}
+          onChange={onChange}
+          value={value}
+        />
+        <div className="absolute flex items-center justify-center mt-3 ml-3">
+          <Search className="fill-current text-grey h-5 w-5" />
+        </div>
       </div>
     </form>
   );

--- a/src/components/tile.js
+++ b/src/components/tile.js
@@ -11,7 +11,7 @@ export const Tile = ({ name, isOpen, children, ...rootProps }) => {
     >
       {children}
       {name && (
-        <span className="absolute tile-hover-text-position opacity-0 text-gray-600 uppercase text-xs font-bold tracking-wider truncate max-w-full transition-opacity duration-300 ease-in-out group-hover:opacity-100">
+        <span className="absolute tile-hover-text-position opacity-50 text-gray-600 text-xs font-bold tracking-wider truncate max-w-full transition-opacity duration-300 ease-in-out group-hover:opacity-100">
           {name}
         </span>
       )}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -284,7 +284,7 @@ export default function IndexPage({ pkgVersion }) {
                   isOpen={iconInView?.name === icon?.name}
                   onClick={() => setIconInView(icon)}
                 >
-                  <Icon className="h-6 w-6" />
+                  <Icon className="-mt-4 h-6 w-6" />
                 </Tile>
               );
             })}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -197,37 +197,35 @@ export default function IndexPage({ pkgVersion }) {
           </dl>
         </div>
         <SearchField
-            className="mt-10 w-full sm:px-6 md:px-0 md:mb-0"
-            inputClassName="w-full"
-            value={searchText}
-            onChange={(e) => {
-              const search = e.target.value;
+          className="mt-10 w-full sm:px-6 md:px-0 md:mb-0"
+          inputClassName="w-full"
+          value={searchText}
+          onChange={(e) => {
+            const search = e.target.value;
 
-              setSearchText(e.target.value);
+            setSearchText(e.target.value);
 
-              const filteredIcons =
-                selectedTab !== 'all'
-                  ? getChromicons()?.filter((icon) =>
-                      icon?.categories?.includes(selectedTab)
-                    )
-                  : getChromicons();
+            const filteredIcons =
+              selectedTab !== 'all'
+                ? getChromicons()?.filter((icon) =>
+                    icon?.categories?.includes(selectedTab)
+                  )
+                : getChromicons();
 
-              if (!search) {
-                setVisibleIcons(filteredIcons);
-                return;
-              }
+            if (!search) {
+              setVisibleIcons(filteredIcons);
+              return;
+            }
 
-              setVisibleIcons(
-                filteredIcons?.filter(
-                  (icon) =>
-                    icon.name.toLowerCase().includes(search.toLowerCase()) ||
-                    icon?.keywords
-                      ?.toLowerCase()
-                      ?.includes(search.toLowerCase())
-                )
-              );
-            }}
-          />
+            setVisibleIcons(
+              filteredIcons?.filter(
+                (icon) =>
+                  icon.name.toLowerCase().includes(search.toLowerCase()) ||
+                  icon?.keywords?.toLowerCase()?.includes(search.toLowerCase())
+              )
+            );
+          }}
+        />
       </header>
 
       <main className="bg-white text-gray-600 scrolling-touch">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -125,9 +125,9 @@ export default function IndexPage({ pkgVersion }) {
           <div className="py-12 flex items-center text-white space-x-2">
             <Chromicons />
 
-            <dl className="mt-0 mb-1 inline-flex items-center px-2 rounded-full text-xs bg-gradient-to-r from-super-orange to-super-blue">
+            <dl className="inline-flex self-end items-center px-2 rounded-full text-xs bg-gradient-to-r from-super-orange to-super-blue">
               <dt className="sr-only">Chromicons version</dt>
-              <dd>{pkgVersion}</dd>
+              <dd className="text-black">{pkgVersion}</dd>
             </dl>
           </div>
           <nav
@@ -196,12 +196,44 @@ export default function IndexPage({ pkgVersion }) {
             </div>
           </dl>
         </div>
+        <SearchField
+            className="mt-10 w-full sm:px-6 md:px-0 md:mb-0"
+            inputClassName="w-full"
+            value={searchText}
+            onChange={(e) => {
+              const search = e.target.value;
+
+              setSearchText(e.target.value);
+
+              const filteredIcons =
+                selectedTab !== 'all'
+                  ? getChromicons()?.filter((icon) =>
+                      icon?.categories?.includes(selectedTab)
+                    )
+                  : getChromicons();
+
+              if (!search) {
+                setVisibleIcons(filteredIcons);
+                return;
+              }
+
+              setVisibleIcons(
+                filteredIcons?.filter(
+                  (icon) =>
+                    icon.name.toLowerCase().includes(search.toLowerCase()) ||
+                    icon.description
+                      .toLowerCase()
+                      .includes(search.toLowerCase())
+                )
+              );
+            }}
+          />
       </header>
 
       <main className="bg-white text-gray-600 scrolling-touch">
-        <div className="flex justify-between items-center shadow-banner px-4 flex-col md:flex-row sm:px-6 lg:px-16">
+        <div className="flex justify-between items-center shadow-banner px-4 flex-col sm:px-6 lg:px-16">
           <CategoryFilters
-            className="mt-4"
+            className="-mt-4"
             selectedTab={selectedTab}
             onChange={(filter) => {
               setSelectedTab(filter);
@@ -240,41 +272,9 @@ export default function IndexPage({ pkgVersion }) {
               }
             }}
           />
-          <SearchField
-            className="mb-4 w-full sm:px-6 md:px-0 md:mb-0 md:w-auto"
-            inputClassName="w-full md:w-auto"
-            value={searchText}
-            onChange={(e) => {
-              const search = e.target.value;
-
-              setSearchText(e.target.value);
-
-              const filteredIcons =
-                selectedTab !== 'all'
-                  ? getChromicons()?.filter((icon) =>
-                      icon?.categories?.includes(selectedTab)
-                    )
-                  : getChromicons();
-
-              if (!search) {
-                setVisibleIcons(filteredIcons);
-                return;
-              }
-
-              setVisibleIcons(
-                filteredIcons?.filter(
-                  (icon) =>
-                    icon.name.toLowerCase().includes(search.toLowerCase()) ||
-                    icon.description
-                      .toLowerCase()
-                      .includes(search.toLowerCase())
-                )
-              );
-            }}
-          />
         </div>
         {visibleIcons?.length > 0 ? (
-          <div className="grid grid-cols-2 gap-2 px-4 my-4 max-w-6xl mx-auto sm:px-6 lg:px-16 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+          <div className="flex flex-wrap justify-center px-4 my-4 max-w-6xl mx-auto sm:px-6 lg:px-16">
             {visibleIcons?.map((icon) => {
               const Icon = icon.reactComponent;
               return (


### PR DESCRIPTION
### CHANGES
- Move `<SearchField` into hero and center
- Center tab navigation for all screen sizes
- Make icon labels visible by default. After I search, I want to immediately read the icon name so I can type it in the repo I'm working in. The hover is an extra annoying step for me to get to the icon I want to use.
- Make icon labels camel case. Uppercase is harder to read especially when file names get longer.
- Center icon results (replace grid with flex layout). When icon search only results in one icon, the solitary left-aligned icon was triggering me.
- Improve Chromicons logo and pill version alignment and legibility (top left of page)


&nbsp; | BEFORE | AFTER
-- | -- | --
MD-XL | <img width="1462" alt="Screen Shot 2021-05-12 at 4 42 21 PM" src="https://user-images.githubusercontent.com/485903/118041780-3b0ebd80-b341-11eb-9268-e2423515292f.png"> | <img width="1462" alt="Screen Shot 2021-05-12 at 4 42 24 PM" src="https://user-images.githubusercontent.com/485903/118041788-3cd88100-b341-11eb-8490-2c7b0b3b0bd2.png">
XS-SM | <img width="612" alt="Screen Shot 2021-05-12 at 4 42 34 PM" src="https://user-images.githubusercontent.com/485903/118041791-3d711780-b341-11eb-8da3-c91e08c243de.png"> | <img width="612" alt="Screen Shot 2021-05-12 at 4 42 39 PM" src="https://user-images.githubusercontent.com/485903/118041795-3e09ae00-b341-11eb-827b-98162974e587.png">
Center Search Results | <img width="1163" alt="Screen Shot 2021-05-12 at 4 53 47 PM" src="https://user-images.githubusercontent.com/485903/118042939-b58c0d00-b342-11eb-9965-70e49eb7aa73.png"> | <img width="1163" alt="Screen Shot 2021-05-12 at 5 02 29 PM" src="https://user-images.githubusercontent.com/485903/118043832-e3be1c80-b343-11eb-9969-6a5b8aa98438.png">



