### PR TITLE
DEPS: Fix package.json due to yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "next:start": "next start"
   },
   "dependencies": {
-    "@lifeomic/chromicons": "^0.1.5",
+    "@lifeomic/chromicons": "^0.1.6",
     "@reach/alert": "^0.11.2",
     "@reach/dialog": "^0.11.2",
     "@tailwindui/react": "^0.1.1",


### PR DESCRIPTION
Pulling the repo down and running `yarn`, looks like it was trying to use the old version still.  Bumping the version in `package.json` seems to make it happy.  When bumping the chromicons package, be sure to run `yarn upgrade @lifeomic/chromicons@latest` and that should bump the `package.json` as well as the `yarn.lock` 👍 