### PR TITLE
Widen tiles to better accommodate longer icon names

### DIFF
--- a/src/components/tile.js
+++ b/src/components/tile.js
@@ -4,7 +4,7 @@ export const Tile = ({ name, isOpen, children, ...rootProps }) => {
       aria-label={`${name} icon`}
       aria-haspopup="true"
       aria-expanded={isOpen}
-      className="rounded-md group relative flex flex-col items-center justify-center px-12 py-12 text-sm duration-300 ease-in-out transition-all transform hover:-translate-y-1 hover:shadow-lg focus:outline-none focus-visible:shadow-outline"
+      className="w-40 rounded-md group relative flex flex-col items-center justify-center px-12 py-12 text-sm duration-300 ease-in-out transition-all transform hover:-translate-y-1 hover:shadow-lg focus:outline-none focus-visible:shadow-outline"
       type="button"
       tabIndex={0}
       {...rootProps}


### PR DESCRIPTION
BEFORE | AFTER
-- | --
<img width="1748" alt="Screen Shot 2021-05-24 at 4 00 58 PM" src="https://user-images.githubusercontent.com/485903/119401559-a04fa080-bca9-11eb-99a9-a34d165cb326.png"> | <img width="1792" alt="Screen Shot 2021-05-24 at 4 00 45 PM" src="https://user-images.githubusercontent.com/485903/119401555-9fb70a00-bca9-11eb-9a61-23ff2c9da391.png">
