### PR TITLE
FIX: Fix tiles container width + remove unused imports

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,6 +1,5 @@
 import { Chromicons } from './icons/chromicons';
 import { Download } from '@lifeomic/chromicons';
-import * as allLinedChromicons from '@lifeomic/chromicons';
 import clsx from 'clsx';
 
 const HeroNavLink = ({ className, children, ...rootProps }) => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,19 +1,15 @@
 import { CategoryFilters } from '../components/categoryFilters';
-import { Chromicons } from '../components/icons/chromicons';
 import { IconModal } from '../components/iconModal';
-import { LifeOmic } from '../components/icons/lifeomic';
 import { SearchField } from '../components/searchField';
 import { Tile } from '../components/tile';
 import { Header } from '../components/header';
 import { Footer } from '../components/footer';
 import { Transition } from '@tailwindui/react';
 import { useState } from 'react';
-import { CheckCircle, Download, Flag, Lifeology } from '@lifeomic/chromicons';
+import { CheckCircle, Flag, Lifeology } from '@lifeomic/chromicons';
 import * as allLinedChromicons from '@lifeomic/chromicons';
-import clsx from 'clsx';
 import Head from 'next/head';
 import metadata from '../util/metadata';
-import Link from 'next/link';
 
 const getChromicons = () => {
   const iconNames = Object.keys(allLinedChromicons);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -247,7 +247,7 @@ export default function IndexPage({ pkgVersion }) {
           </div>
         </div>
         {visibleIcons?.length > 0 ? (
-          <div className="flex flex-wrap justify-center mx-auto bg-white">
+          <div className="flex flex-wrap justify-center mx-auto w-full bg-white">
             {visibleIcons?.map((icon) => {
               const Icon = icon.reactComponent;
               return (


### PR DESCRIPTION
### Changes

- I noticed the tiles container width was dependent on the number of tiles in the row.  Adding a full width class ensures the backing container will always fill the entire space
- I noticed there were some unused imports in a few files, so I deleted those

### BEFORE
<img width="1792" alt="before" src="https://user-images.githubusercontent.com/8069555/123350925-025e2880-d52a-11eb-9cff-58c83d614c56.png">

### AFTER
<img width="1249" alt="after" src="https://user-images.githubusercontent.com/8069555/123350923-012cfb80-d52a-11eb-9d9e-49b31518a3d9.png">


