### PR TITLE
FEAT: adjust flex direction

### DIFF
--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -7,7 +7,7 @@ export const SearchField = ({ className, inputClassName, onChange }) => {
 
   return (
     <form
-      className={clsx('relative flex items-center justify-center', className)}
+      className={clsx('relative flex justify-end', className)}
       onSubmit={(e) => e.preventDefault()}
     >
       <label className="sr-only" htmlFor="search-icons" aria-hidden>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -162,9 +162,9 @@ export default function IndexPage({ pkgVersion }) {
             />
           </div>
         </div>
-        <div className="flex justify-between items-start shadow-banner px-4 lg:flex-row sm:px-6 lg:px-6 bg-white flex-col sm:flex-row">
+        <div className="flex justify-between items-start shadow-banner px-4 sm:px-6 lg:px-6 bg-white flex-col md:flex-row">
           <CategoryFilters
-            className="-mt-4"
+            className="md:-mt-4 md:mr-8 flex w-full justify-evenly md:justify-start whitespace-nowrap"
             selectedTab={selectedTab}
             onChange={(filter) => {
               setSelectedTab(filter);
@@ -203,7 +203,7 @@ export default function IndexPage({ pkgVersion }) {
               }
             }}
           />
-          <div className="pb-6">
+          <div className="pb-6 w-full">
             <SearchField
               className="pt-6 w-full sm:px-6 md:px-0 md:mb-0"
               inputClassName="w-full"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -206,8 +206,8 @@ export default function IndexPage({ pkgVersion }) {
           />
           <div className="pb-6">
             <SearchField
-              className="pt-6 w-full sm:px-6 md:px-0 md:mb-0"
-              inputClassName="w-full"
+              className="pt-6 sm:px-6 md:px-0 md:mb-0"
+              inputClassName=""
               value={searchText}
               onChange={(e) => {
                 const search = e.target.value;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -163,7 +163,7 @@ export default function IndexPage({ pkgVersion }) {
             />
           </div>
         </div>
-        <div className="flex justify-between items-start shadow-banner px-4 lg:flex-row sm:flex-col sm:px-6 lg:px-6 bg-white flex-col sm:flex-row">
+        <div className="flex justify-between items-start shadow-banner px-4 lg:flex-row sm:px-6 lg:px-6 bg-white flex-col sm:flex-row">
           <CategoryFilters
             className="-mt-4"
             selectedTab={selectedTab}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -163,7 +163,7 @@ export default function IndexPage({ pkgVersion }) {
             />
           </div>
         </div>
-        <div className="flex justify-between items-start shadow-banner px-4 lg:flex-row sm:flex-col sm:px-6 lg:px-6 bg-white">
+        <div className="flex justify-between items-start shadow-banner px-4 lg:flex-row sm:flex-col sm:px-6 lg:px-6 bg-white flex-col sm:flex-row">
           <CategoryFilters
             className="-mt-4"
             selectedTab={selectedTab}


### PR DESCRIPTION
BEFORE | AFTER | &nbsp;
-- | -- | --
<img width="620" alt="01-Screen Shot 2021-06-30 at 3 37 06 PM" src="https://user-images.githubusercontent.com/485903/124021194-42edf400-d9b9-11eb-967b-80c3960de55a.png"> | <img width="620" alt="02-Screen Shot 2021-06-30 at 3 36 47 PM" src="https://user-images.githubusercontent.com/485903/124021200-441f2100-d9b9-11eb-9070-ce8bbc2e75a1.png"> | Stack search bar under tabs and center on sm screens
<img width="1792" alt="03-Screen Shot 2021-06-30 at 3 37 30 PM" src="https://user-images.githubusercontent.com/485903/124021203-44b7b780-d9b9-11eb-97be-0ab7cc010005.png"> | <img width="1792" alt="04-Screen Shot 2021-06-30 at 3 37 18 PM" src="https://user-images.githubusercontent.com/485903/124021205-45504e00-d9b9-11eb-9d1f-4b4ab0b598f5.png"> | No visual changes on lg screens
