### PR TITLE
FEAT: add custom clear icon to SearchField

### DIFF
--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -34,7 +34,7 @@ export const SearchField = ({ className, inputClassName, onChange }) => {
 
         <button
           className={clsx(
-            'absolute right-2 top-0 bottom-0 invisible focus:outline-none focus-visible:ring-2',
+            'absolute right-3 top-0 bottom-0 invisible focus:outline-none focus-visible:ring-2',
             searchText?.length > 0 && 'visible'
           )}
           aria-label="Clear search"
@@ -43,7 +43,7 @@ export const SearchField = ({ className, inputClassName, onChange }) => {
             onChange?.('');
           }}
         >
-          <XCircle className="h-4 w-4" aria-hidden />
+          <XCircle className="h-5 w-5 opacity-75 hover:opacity-100" aria-hidden />
         </button>
       </div>
     </form>

--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -43,7 +43,10 @@ export const SearchField = ({ className, inputClassName, onChange }) => {
             onChange?.('');
           }}
         >
-          <XCircle className="h-5 w-5 opacity-75 hover:opacity-100" aria-hidden />
+          <XCircle
+            className="h-5 w-5 opacity-75 hover:opacity-100"
+            aria-hidden
+          />
         </button>
       </div>
     </form>

--- a/src/components/searchField.js
+++ b/src/components/searchField.js
@@ -1,7 +1,10 @@
-import { Search } from '@lifeomic/chromicons';
+import { Search, XCircle } from '@lifeomic/chromicons';
+import { useState } from 'react';
 import clsx from 'clsx';
 
-export const SearchField = ({ className, inputClassName, onChange, value }) => {
+export const SearchField = ({ className, inputClassName, onChange }) => {
+  const [searchText, setSearchText] = useState('');
+
   return (
     <form
       className={clsx('relative flex items-center justify-center', className)}
@@ -19,12 +22,29 @@ export const SearchField = ({ className, inputClassName, onChange, value }) => {
             'appearance-none border border-grey bg-gray-100 rounded-lg pl-10 pr-4 py-2 text-black focus:outline-none focus:border-purple-400',
             inputClassName
           )}
-          onChange={onChange}
-          value={value}
+          onChange={(e) => {
+            setSearchText(e.target.value);
+            onChange?.(e.target.value);
+          }}
+          value={searchText}
         />
         <div className="absolute flex items-center text-gray-400 justify-center mt-3 ml-3">
           <Search className="fill-current h-5 w-5" />
         </div>
+
+        <button
+          className={clsx(
+            'absolute right-2 top-0 bottom-0 invisible focus:outline-none focus-visible:ring-2',
+            searchText?.length > 0 && 'visible'
+          )}
+          aria-label="Clear search"
+          onClick={() => {
+            setSearchText('');
+            onChange?.('');
+          }}
+        >
+          <XCircle className="h-4 w-4" aria-hidden />
+        </button>
       </div>
     </form>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -37,7 +37,6 @@ export function getStaticProps() {
 export default function IndexPage({ pkgVersion }) {
   const [iconInView, setIconInView] = useState(null);
   const [selectedTab, setSelectedTab] = useState('all');
-  const [searchText, setSearchText] = useState('');
 
   const [visibleIcons, setVisibleIcons] = useState(() => getChromicons('all'));
 
@@ -208,12 +207,7 @@ export default function IndexPage({ pkgVersion }) {
             <SearchField
               className="pt-6 w-full sm:px-6 md:px-0 md:mb-0"
               inputClassName="w-full"
-              value={searchText}
-              onChange={(e) => {
-                const search = e.target.value;
-
-                setSearchText(e.target.value);
-
+              onChange={(search) => {
                 const filteredIcons =
                   selectedTab !== 'all'
                     ? getChromicons()?.filter((icon) =>
@@ -273,7 +267,7 @@ export default function IndexPage({ pkgVersion }) {
               <p>It looks like we don't have an icon for that yet!</p>
               <a
                 href={`https://github.com/lifeomic/chromicons/issues/new?title=${encodeURIComponent(
-                  `"${searchText}" icon request`
+                  'Icon request'
                 )}`}
                 className="text-sm text-blue-600 duration-300 ease-in-out transition-opacity hover:opacity-75 focus:outline-none focus-visible:shadow-outline focus-visible:underline"
                 target="_blank"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -61,6 +61,10 @@
   }
 }
 
+input[type='search']::-webkit-search-cancel-button {
+  display: none;
+}
+
 /* Start purging... */
 @tailwind utilities;
 /* Stop purging. */


### PR DESCRIPTION
It was sacrilege that we weren't using a Chromicon for the clear icon in search bar!  😝 

Thanks to @ynotdraw for doing all the work on this one! We'll need someone other than Tony to approve this so it gets past the CM Bot.

BEFORE | AFTER
-- | --
<img width="262" alt="Screen Shot 2021-06-29 at 12 09 45 PM" src="https://user-images.githubusercontent.com/485903/123832078-f92ade00-d8d2-11eb-8dd1-3a284c540a50.png"> | <img width="262" alt="Screen Shot 2021-06-29 at 12 09 53 PM" src="https://user-images.githubusercontent.com/485903/123832079-f92ade00-d8d2-11eb-8312-fb7c1a2e4af6.png">
