### PR TITLE
fix: Bump Chromicons to v3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "next:start": "next start"
   },
   "dependencies": {
-    "@lifeomic/chromicons": "^3.3.0",
+    "@lifeomic/chromicons": "^3.3.1",
     "@reach/alert": "^0.11.2",
     "@reach/dialog": "^0.11.2",
     "@tailwindui/react": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,10 +66,10 @@
   dependencies:
     purgecss "^3.1.3"
 
-"@lifeomic/chromicons@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-3.3.0.tgz#b6ef01058a5a7d7bd879fb3b314221935c7863e4"
-  integrity sha512-VCFyHL4LE4fgddToZCiplHwRchwtd3YFwWALIrINlYlNri93rTlIoXOlZx/aK8Xm7xRtbFlDBuBdbv929qKalw==
+"@lifeomic/chromicons@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-3.3.1.tgz#d9b120cdb833ddce8b03746e2021a02f3c21313b"
+  integrity sha512-I3RDY7RHPWiIMh74ax6YZuCPUgmU2mTg6WnuRGL9GhyDL+LHwtlYRISQlgvDqemq558bgPOpUMuUyEH7lFl+/A==
 
 "@next/env@12.1.0":
   version "12.1.0"


### PR DESCRIPTION
Fix snap lines to end points on `refresh-cw`

Related PR: https://github.com/lifeomic/chromicons/pull/152